### PR TITLE
Add support for Code - OSS (self compiled version)

### DIFF
--- a/src/core/Environment.ts
+++ b/src/core/Environment.ts
@@ -33,6 +33,10 @@ export class Environment
         "VSCodium": {
             extensionsDirectoryName: ".vscode-oss",
             dataDirectoryName: "VSCodium"
+        },
+        "Code - OSS": {
+            extensionsDirectoryName: ".vscode-oss",
+            dataDirectoryName: "Code - OSS"
         }
     };
 


### PR DESCRIPTION
When compiling vscode yourself the default values for the name of the executable is "Code - OSS" (see https://github.com/Microsoft/vscode/blob/f25673e310ba6359bf0fa8f228455a17ce554983/product.json#L3).
The extension directory is ".vscode-oss" (See https://github.com/Microsoft/vscode/blob/f25673e310ba6359bf0fa8f228455a17ce554983/product.json#L5).
And the data directory name is "Code - OSS".

This will also ensure compatability with the Arch Linux package code (https://www.archlinux.org/packages/community/x86_64/code/) which is compiled with the default values stated above.