### PR TITLE
Added support for VSCode Exploration builds

### DIFF
--- a/src/core/Environment.ts
+++ b/src/core/Environment.ts
@@ -30,6 +30,10 @@ export class Environment
             extensionsDirectoryName: ".vscode-insiders",
             dataDirectoryName: "Code - Insiders"
         },
+        "Visual Studio Code - Exploration": {
+            extensionsDirectoryName: ".vscode-exploration",
+            dataDirectoryName: "Code - Exploration"
+        },
         "VSCodium": {
             extensionsDirectoryName: ".vscode-oss",
             dataDirectoryName: "VSCodium"


### PR DESCRIPTION
Added VSCode Exploration enviroment support.
Ran local tests and should fix  #50 .

Current exploration builds are based from https://github.com/Microsoft/vscode/tree/electron-4.0.x

Link to the builds can be found in the original issue.