### PR TITLE
Support code-server

### DIFF
--- a/src/utils/vscodeAPI.ts
+++ b/src/utils/vscodeAPI.ts
@@ -104,6 +104,9 @@ export function getVSCodeEdition()
         case "Code - OSS":
             return VSCodeEdition.OSS;
 
+        case "code-server":
+            return VSCodeEdition.CODER;
+
         default:
             throw new Error(localize("error.env.unknown.vscode"));
     }


### PR DESCRIPTION
Adds the right appName for Coder’s code-server, as per [build.sh](https://github.com/coder/code-server/blob/main/ci/build/build-vscode.sh#L19). Otherwise, syncing fails to detect the vscode edition and fails.