### PR TITLE
Fix dir names for code-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,3 +242,9 @@ You can now let Syncing auto-sync your settings. Here are the steps:
 1. Download:
 
     ![download example](docs/gif/Example-Download.gif)
+
+## Frequently Asked Questions
+
+1. How do I make this work with [code-server](https://github.com/coder/code-server)?
+
+    Code-server follows the XDG spec to set config & data directories. When using their [Docker image](https://hub.docker.com/r/codercom/code-server), you can set `XDG_DATA_HOME="/home/coder/.config/"` to store everything files in the same directory. This enables vscode-syncing to easily pickup the right locations. Since it is also a recommended volume path, it ensures persistence of your changes.

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -59,5 +59,9 @@ export const VSCODE_BUILTIN_ENVIRONMENTS: Record<VSCodeEdition, {
     [VSCodeEdition.CODER]: {
         dataDirectoryName: "Code",
         extensionsDirectoryName: "vscode"
+    },
+    [VSCodeEdition.CODESERVER]: {
+        dataDirectoryName: "code-server",
+        extensionsDirectoryName: ".config/code-server"
     }
 };

--- a/src/types/VSCodeEdition.ts
+++ b/src/types/VSCodeEdition.ts
@@ -32,5 +32,10 @@ export enum VSCodeEdition
     /**
      * The VSCode provided by [Coder](https://coder.com), which is running on a remote or self-hosted server.
      */
-    CODER
+    CODER,
+
+    /**
+     * The OSS VSCode server provided by [Coder](https://coder.com), which is running on a remote or self-hosted server.
+     */
+    CODESERVER
 }

--- a/src/utils/vscodeAPI.ts
+++ b/src/utils/vscodeAPI.ts
@@ -105,7 +105,7 @@ export function getVSCodeEdition()
             return VSCodeEdition.OSS;
 
         case "code-server":
-            return VSCodeEdition.CODER;
+            return VSCodeEdition.CODESERVER;
 
         default:
             throw new Error(localize("error.env.unknown.vscode"));


### PR DESCRIPTION
Follow-up to https://github.com/nonoroazoro/vscode-syncing/pull/94:

I was investigating why code-server was not picking up the settings/extensions from vscode-syncing.
It turns out that the path building logic is completely different between them - [vscode-syncing](https://github.com/nonoroazoro/vscode-syncing/blob/master/src/core/Environment.ts#L66) vs [code-server](https://github.com/coder/code-server/blob/b562d4a880f21aace51b6bd1e7ac64330d023b3a/src/node/util.ts#L60).

I've tried to keep my changes minimal and redid my previous changes to prevent a clash between the Coder's platform vs Coder's code-server. I also built and tested these changes locally, so I can confirm they work across my official vscode and remote code-server setup. I can confirm that VSIXs downloaded from the marketplace do work on code-server.

Do let me know what you think!